### PR TITLE
Update leaderboard with 2092 and 2020 solved issue points

### DIFF
--- a/kroc'24/README.md
+++ b/kroc'24/README.md
@@ -3,6 +3,8 @@
 | Name            | Activity                                                                                                          | Points |
 | --------------- | ----------------------------------------------------------------------------------------------------------------- | ------ |
 | Yaten Dhingra                | Issue: [#2074](https://github.com/keploy/keploy/issues/2074), PR: [#49](https://github.com/keploy/website/pull/49) |    4    |
+| Ashutosh Gupta                | Issue: [#2092](https://github.com/keploy/keploy/issues/2092), PR: [#422](https://github.com/keploy/docs/pull/422) |    3    |
+|               | Issue: [#2020](https://github.com/keploy/keploy/issues/2020), PR: [#417](https://github.com/keploy/docs/pull/417) |    4    |
 |                 |                                                                                                                   |        |
 |                 |                                                                                                                   |        |
 |                 |                                                                                                                   |        |


### PR DESCRIPTION
The PR aims to update the leaderboard by adding points for closed issues by merged PRs: https://github.com/keploy/keploy/issues/2092 and https://github.com/keploy/keploy/issues/2020