### PR TITLE
chore: replace the slack url to updated invite url

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center"> Welcome to Keploy 👋 </h1>
 
 <!-- <h3 align="center">
-  <b><a href="https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg">Slack</a></b>
+  <b><a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA">Slack</a></b>
   •
   <a href="https://github.com/keploy">Github</a>
   •
@@ -35,7 +35,7 @@
   	&nbsp;
    <a href="https://community.keploy.io/" target="_blank"><img src="https://img.shields.io/badge/Blog-0A0A0A.svg?style=for-the-badge&logo=rss&logoColor=white"></a>
   	&nbsp;
-   <a href="https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg" target="_blank"><img src="https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white"></a>
+   <a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA" target="_blank"><img src="https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white"></a>
   	&nbsp;
    <a href="https://docs.keploy.io" target="_blank"><img src="https://img.shields.io/badge/Documentation-FF914D?style=for-the-badge&logo=mdnwebdocs&logoColor=white"></a>
   	&nbsp;
@@ -43,7 +43,7 @@
 
 <div align="center">
 
-[<kbd><br><b> ⭐ Star and try Out Keploy ➜ </b><br></kbd>](https://keploy.io) [<kbd><br><b> 👥 Join our Keploy Community ➜ </b><br></kbd>](https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg)
+[<kbd><br><b> ⭐ Star and try Out Keploy ➜ </b><br></kbd>](https://keploy.io) [<kbd><br><b> 👥 Join our Keploy Community ➜ </b><br></kbd>](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA)
 
 </div>
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -7,7 +7,7 @@
 <h1 align="center"> Welcome to Keploy 👋 </h1>
 
 <!-- <h3 align="center">
-  <b><a href="https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg">Slack</a></b>
+  <b><a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA">Slack</a></b>
   •
   <a href="https://github.com/keploy">Github</a>
   •
@@ -35,7 +35,7 @@
   	&nbsp;
    <a href="https://community.keploy.io/" target="_blank"><img src="https://img.shields.io/badge/Blog-0A0A0A.svg?style=for-the-badge&logo=rss&logoColor=white"></a>
   	&nbsp;
-   <a href="https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg" target="_blank"><img src="https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white"></a>
+   <a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA" target="_blank"><img src="https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white"></a>
   	&nbsp;
    <a href="https://docs.keploy.io" target="_blank"><img src="https://img.shields.io/badge/Documentation-FF914D?style=for-the-badge&logo=mdnwebdocs&logoColor=white"></a>
   	&nbsp;
@@ -43,7 +43,7 @@
 
 <div align="center">
 
-[<kbd><br><b> ⭐ Star and try Out Keploy ➜ </b><br></kbd>](https://keploy.io) [<kbd><br><b> 👥 Join our Keploy Community ➜ </b><br></kbd>](https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg)
+[<kbd><br><b> ⭐ Star and try Out Keploy ➜ </b><br></kbd>](https://keploy.io) [<kbd><br><b> 👥 Join our Keploy Community ➜ </b><br></kbd>](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA)
 
 </div>
 


### PR DESCRIPTION
## Summary

Updates the expired Slack community invite URL to the new working link across the repository.

## Changes

- Updated 3 Slack invite links in `README.md`
- Updated 3 Slack invite links in `profile/README.md`

## Why

The old invite link (`zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg`) was no longer valid, causing visitors clicking "Join our Keploy Community" to land on a broken page. This replaces it with the current active invite.

## Type of Change

- [x] Chore (non-breaking change that doesn't add functionality)
