### PR TITLE
chore: replace the temp slack url to permanent route

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center"> Welcome to Keploy 👋 </h1>
 
 <!-- <h3 align="center">
-  <b><a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA">Slack</a></b>
+  <b><a href="https://keploy.io/slack">Slack</a></b>
   •
   <a href="https://github.com/keploy">Github</a>
   •
@@ -20,7 +20,7 @@
   <a href="https://discord.gg/jdTCGQFFw3">Discord</a>
   
 </h3> -->
-<h5 align="center">`
+<h5 align="center">
 
 [Keploy](https://keploy.io/) is a next-gen E2E testing tool that provides an easy way to capture and generate tests(KTests) and data-mocks(KMocks) from real API calls.
 
@@ -35,7 +35,7 @@
   	&nbsp;
    <a href="https://community.keploy.io/" target="_blank"><img src="https://img.shields.io/badge/Blog-0A0A0A.svg?style=for-the-badge&logo=rss&logoColor=white"></a>
   	&nbsp;
-   <a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA" target="_blank"><img src="https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white"></a>
+   <a href="https://keploy.io/slack" target="_blank"><img src="https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white"></a>
   	&nbsp;
    <a href="https://docs.keploy.io" target="_blank"><img src="https://img.shields.io/badge/Documentation-FF914D?style=for-the-badge&logo=mdnwebdocs&logoColor=white"></a>
   	&nbsp;
@@ -43,7 +43,7 @@
 
 <div align="center">
 
-[<kbd><br><b> ⭐ Star and try Out Keploy ➜ </b><br></kbd>](https://keploy.io) [<kbd><br><b> 👥 Join our Keploy Community ➜ </b><br></kbd>](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA)
+[<kbd><br><b> ⭐ Star and try Out Keploy ➜ </b><br></kbd>](https://keploy.io) [<kbd><br><b> 👥 Join our Keploy Community ➜ </b><br></kbd>](https://keploy.io/slack)
 
 </div>
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -7,7 +7,7 @@
 <h1 align="center"> Welcome to Keploy 👋 </h1>
 
 <!-- <h3 align="center">
-  <b><a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA">Slack</a></b>
+  <b><a href="https://keploy.io/slack">Slack</a></b>
   •
   <a href="https://github.com/keploy">Github</a>
   •
@@ -35,7 +35,7 @@
   	&nbsp;
    <a href="https://community.keploy.io/" target="_blank"><img src="https://img.shields.io/badge/Blog-0A0A0A.svg?style=for-the-badge&logo=rss&logoColor=white"></a>
   	&nbsp;
-   <a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA" target="_blank"><img src="https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white"></a>
+   <a href="https://keploy.io/slack" target="_blank"><img src="https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white"></a>
   	&nbsp;
    <a href="https://docs.keploy.io" target="_blank"><img src="https://img.shields.io/badge/Documentation-FF914D?style=for-the-badge&logo=mdnwebdocs&logoColor=white"></a>
   	&nbsp;
@@ -43,7 +43,7 @@
 
 <div align="center">
 
-[<kbd><br><b> ⭐ Star and try Out Keploy ➜ </b><br></kbd>](https://keploy.io) [<kbd><br><b> 👥 Join our Keploy Community ➜ </b><br></kbd>](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA)
+[<kbd><br><b> ⭐ Star and try Out Keploy ➜ </b><br></kbd>](https://keploy.io) [<kbd><br><b> 👥 Join our Keploy Community ➜ </b><br></kbd>](https://keploy.io/slack)
 
 </div>
 


### PR DESCRIPTION
## Summary

- Replaces all instances of the temporary Slack invite URL (`join.slack.com/t/keploy/shared_invite/...`) with the permanent redirect `https://keploy.io/slack` across `README.md` and `profile/README.md`
- Also fixes a stray backtick in `README.md` inside the `<h5>` tag (rendering artifact)

## Files changed

- `README.md` - 3 URL replacements + stray backtick fix
- `profile/README.md` - 3 URL replacements

## Notes

The Slack webhook URL in `.github/workflows/notification.yml` (`SLACK_WEBHOOK_URL` secret) is unrelated and was intentionally left unchanged.
